### PR TITLE
Revert package names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        rust: [ 1.59.0, stable ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [1.60.0, stable]
 
     steps:
       - name: Checkout sources
@@ -42,8 +42,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        rust: [ 1.59.0, stable ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [1.60.0, stable]
 
     defaults:
       run:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [1.59.0, stable]
+        rust: [1.60.0, stable]
         make:
           - name: Clippy
             task: "cargo clippy"
@@ -36,4 +36,3 @@ jobs:
 
       - name: ${{ matrix.make.name }}
         run: ${{ matrix.make.task }}
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "atty"
@@ -25,7 +25,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -79,22 +79,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"
@@ -142,10 +130,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
+name = "cosmwasm-crypto"
+version = "1.1.0"
+dependencies = [
+ "base64",
+ "criterion",
+ "digest 0.10.6",
+ "ed25519-zebra",
+ "english-numbers",
+ "hex",
+ "hex-literal",
+ "k256",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.6",
+ "thiserror",
+]
+
+[[package]]
 name = "cosmwasm-derive"
 version = "1.1.0"
 dependencies = [
- "secret-cosmwasm-std",
+ "cosmwasm-std",
  "syn",
 ]
 
@@ -170,6 +177,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "cosmwasm-std"
+version = "1.1.0"
+dependencies = [
+ "base64",
+ "chrono",
+ "cosmwasm-crypto",
+ "cosmwasm-derive",
+ "cosmwasm-schema",
+ "derivative",
+ "forward_ref",
+ "hex",
+ "hex-literal",
+ "schemars",
+ "serde",
+ "serde-json-wasm",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
+name = "cosmwasm-storage"
+version = "1.1.0"
+dependencies = [
+ "cosmwasm-std",
+ "serde",
 ]
 
 [[package]]
@@ -290,13 +325,12 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.6"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+checksum = "af91f40b7355f82b0a891f50e70399475945bb0b0da4f1700ce60761c9d3e359"
 dependencies = [
- "bstr",
  "csv-core",
- "itoa 0.4.8",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -366,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
 name = "ecdsa"
@@ -399,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
@@ -431,9 +465,9 @@ checksum = "4e4f5d6e192964d498b45abee72ca445e91909094bc8e8791259e82c2a0d1aa6"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -511,6 +545,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,21 +594,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -590,9 +627,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "log"
@@ -639,19 +676,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -705,18 +742,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -748,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -769,18 +806,12 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -810,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "same-file"
@@ -868,63 +899,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "secret-cosmwasm-crypto"
-version = "1.1.0"
-dependencies = [
- "base64",
- "criterion",
- "digest 0.10.6",
- "ed25519-zebra",
- "english-numbers",
- "hex",
- "hex-literal",
- "k256",
- "rand_core 0.6.4",
- "serde",
- "serde_json",
- "sha2 0.10.6",
- "thiserror",
-]
-
-[[package]]
-name = "secret-cosmwasm-std"
-version = "1.1.0"
-dependencies = [
- "base64",
- "chrono",
- "cosmwasm-derive",
- "cosmwasm-schema",
- "derivative",
- "forward_ref",
- "hex",
- "hex-literal",
- "schemars",
- "secret-cosmwasm-crypto",
- "serde",
- "serde-json-wasm",
- "thiserror",
- "uint",
-]
-
-[[package]]
-name = "secret-cosmwasm-storage"
-version = "1.1.0"
-dependencies = [
- "secret-cosmwasm-std",
- "serde",
-]
-
-[[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -950,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -972,11 +956,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
- "itoa 1.0.4",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1039,9 +1023,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1073,18 +1057,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1121,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-width"
@@ -1156,9 +1140,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1166,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -1181,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1191,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1204,15 +1188,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,15 +33,15 @@ checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea908e7347a8c64e378c17e30ef880ad73e3b4498346b055c2c00ea342f3179"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "blake2b_simd"
@@ -54,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
@@ -75,15 +86,26 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "cosmwasm-crypto"
+version = "1.1.0"
+dependencies = [
+ "digest 0.10.6",
+ "ed25519-zebra",
+ "k256",
+ "rand_core 0.6.4",
+ "thiserror",
+]
 
 [[package]]
 name = "cosmwasm-derive"
@@ -113,31 +135,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+name = "cosmwasm-std"
+version = "1.1.0"
 dependencies = [
- "libc",
+ "base64",
+ "cosmwasm-crypto",
+ "cosmwasm-derive",
+ "derivative",
+ "forward_ref",
+ "hex",
+ "schemars",
+ "serde",
+ "serde-json-wasm",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
+name = "cosmwasm-storage"
+version = "1.1.0"
+dependencies = [
+ "cosmwasm-std",
+ "serde",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
- "lazy_static",
 ]
 
 [[package]]
@@ -148,12 +185,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2b443d17d49dad5ef0ede301c3179cc923b8822f3393b4d2c28c269dd4a122"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -170,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -183,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -213,26 +250,26 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer 0.10.3",
  "crypto-common",
  "subtle",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.4"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.3"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd46e0c364655e5baf2f5e99b603e7a09905da9966d7928d7470af393b28670"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -242,34 +279,34 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
+checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
  "curve25519-dalek",
+ "hashbrown",
  "hex",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "serde",
- "sha2 0.9.5",
- "thiserror",
+ "sha2 0.9.9",
  "zeroize",
 ]
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c47abd0a791d2ac0c7aa1118715f85b83689e4522c4e3a244e159d4fc9848a8d"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.3",
+ "digest 0.10.6",
  "ff",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -277,11 +314,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -293,9 +330,9 @@ checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -303,34 +340,23 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "group"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -339,13 +365,22 @@ name = "hackatom"
 version = "0.0.0"
 dependencies = [
  "cosmwasm-schema",
+ "cosmwasm-std",
+ "cosmwasm-storage",
  "rust-argon2",
  "schemars",
- "secret-cosmwasm-std",
- "secret-cosmwasm-storage",
  "serde",
- "sha2 0.10.3",
+ "sha2 0.10.6",
  "thiserror",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -360,38 +395,38 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "k256"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8a5a96d92d849c4499d99461da81c9cdc1467418a8ed2aaeb407e8d85940ed"
+checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.3",
+ "sha2 0.10.6",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
+name = "libc"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
-name = "libc"
-version = "0.2.126"
+name = "once_cell"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -411,18 +446,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -432,24 +467,21 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom",
 ]
 
 [[package]]
 name = "rfc6979"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c86280f057430a52f4861551b092a01b419b8eacefc7c995eacb9dc132fe32"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint",
  "hmac",
@@ -470,15 +502,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "schemars"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a48d098c2a7fdf5740b19deb1181b4fb8a9e68e03ae517c14cde04b5725409"
+checksum = "2a5fb6c61f29e723026dc8e923d94c694313212abbecbbe5f55a7748eec5b307"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -488,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9ea2a613fe4cd7118b2bb101a25d8ae6192e1975179b67b2f17afd11e70ac8"
+checksum = "f188d036977451159430f3b8dc82ec76364a42b7e289c2b18a9a18f4470058e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -513,46 +545,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "secret-cosmwasm-crypto"
-version = "1.1.0"
-dependencies = [
- "digest 0.10.3",
- "ed25519-zebra",
- "k256",
- "rand_core 0.6.3",
- "thiserror",
-]
-
-[[package]]
-name = "secret-cosmwasm-std"
-version = "1.1.0"
-dependencies = [
- "base64",
- "cosmwasm-derive",
- "derivative",
- "forward_ref",
- "hex",
- "schemars",
- "secret-cosmwasm-crypto",
- "serde",
- "serde-json-wasm",
- "thiserror",
- "uint",
-]
-
-[[package]]
-name = "secret-cosmwasm-storage"
-version = "1.1.0"
-dependencies = [
- "secret-cosmwasm-std",
- "serde",
-]
-
-[[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -568,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -579,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -590,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -601,36 +597,36 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures 0.1.5",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899bf02746a2c92bf1053d9327dadb252b01af1f81f90cdb902411f518bc7215"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.2",
- "digest 0.10.3",
+ "cpufeatures",
+ "digest 0.10.6",
 ]
 
 [[package]]
 name = "signature"
-version = "1.5.0"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.10.3",
- "rand_core 0.6.3",
+ "digest 0.10.6",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -657,29 +653,29 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -688,15 +684,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "uint"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f03af7ccf01dd611cc450a0d10dbc9b745770d096473e2faf0ca6e2d66d1e0"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -705,28 +701,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zeroize"

--- a/contracts/hackatom/Cargo.toml
+++ b/contracts/hackatom/Cargo.toml
@@ -30,7 +30,9 @@ backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
-cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std", default-features = false, features = ["abort"] }
+cosmwasm-std = { path = "../../packages/std", default-features = false, features = [
+    "abort",
+] }
 rust-argon2 = "0.8"
 schemars = "0.8.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -38,4 +40,4 @@ sha2 = "0.10"
 thiserror = "1.0"
 
 [dev-dependencies]
-cosmwasm-storage = { path = "../../packages/storage", package = "secret-cosmwasm-storage", default-features = false }
+cosmwasm-storage = { path = "../../packages/storage", default-features = false }

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
-name = "secret-cosmwasm-crypto"
+name = "cosmwasm-crypto"
 version = "1.1.0"
-authors = ["Mauro Lacy <maurolacy@users.noreply.github.com>", "SCRT Labs <info@scrtlabs.com>"]
+authors = [
+    "Mauro Lacy <maurolacy@users.noreply.github.com>",
+    "SCRT Labs <info@scrtlabs.com>",
+]
 edition = "2021"
 description = "Crypto bindings for cosmwasm contracts"
 repository = "https://github.com/scrtlabs/cosmwasm/tree/secret/packages/crypto"
@@ -27,7 +30,10 @@ thiserror = "1.0.13"
 
 [dev-dependencies]
 criterion = "0.3"
-serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
+serde = { version = "1.0.103", default-features = false, features = [
+    "derive",
+    "alloc",
+] }
 serde_json = "1.0.40"
 sha2 = "0.10"
 base64 = "0.13.0"

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -1,12 +1,10 @@
 # CosmWasm Crypto
 
-[![secret-cosmwasm-crypto on crates.io](https://img.shields.io/crates/v/secret-cosmwasm-crypto.svg)](https://crates.io/crates/secret-cosmwasm-crypto)
-
 NOTE: This is a fork of the original cosmwasm-storage repository adapted for use in [SecretNetwork](https://scrt.network)'s Secret Contracts.
 
 This crate implements cryptography-related functions, so that they can be
-available for both, the [cosmwasm-vm](`https://crates.io/crates/cosmwasm-vm`)
-and [cosmwasm-std](`https://crates.io/crates/cosmwasm-std`) crates.
+available for both, the [cosmwasm-vm](`<https://crates.io/crates/cosmwasm-vm>`)
+and [cosmwasm-std](`<https://crates.io/crates/cosmwasm-std>`) crates.
 
 ## Implementations
 

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -22,4 +22,4 @@ syn = { version = "1.0", features = ["full"] }
 # "What's even more fun, Cargo packages actually can have cyclic dependencies.
 # "(a package can have an indirect dev-dependency on itself)"
 # https://users.rust-lang.org/t/does-cargo-support-cyclic-dependencies/35666/3
-cosmwasm-std = { package = "secret-cosmwasm-std", path = "../std" }
+cosmwasm-std = { package = "cosmwasm-std", path = "../std" }

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -22,4 +22,4 @@ syn = { version = "1.0", features = ["full"] }
 # "What's even more fun, Cargo packages actually can have cyclic dependencies.
 # "(a package can have an indirect dev-dependency on itself)"
 # https://users.rust-lang.org/t/does-cargo-support-cyclic-dependencies/35666/3
-cosmwasm-std = { package = "cosmwasm-std", path = "../std" }
+cosmwasm-std = { path = "../std" }

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
-name = "secret-cosmwasm-std"
+name = "cosmwasm-std"
 version = "1.1.0"
-authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>", "SCRT Labs <info@scrtlabs.com>"]
+authors = [
+    "Ethan Frey <ethanfrey@users.noreply.github.com>",
+    "SCRT Labs <info@scrtlabs.com>",
+]
 edition = "2021"
 description = "Standard library for Wasm based smart contracts on Cosmos blockchains"
 repository = "https://github.com/scrtlabs/cosmwasm/tree/secret/packages/std"
@@ -45,7 +48,7 @@ serde-json-wasm = { version = "0.4.1" }
 schemars = "0.8.3"
 serde = { version = "1.0.103", default-features = false, features = [
     "derive",
-    "alloc"
+    "alloc",
 ] }
 thiserror = "1.0.13"
 forward_ref = "1"
@@ -54,14 +57,14 @@ hex = "0.4"
 uint = "0.9.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-cosmwasm-crypto = { path = "../crypto", package = "secret-cosmwasm-crypto", version = "1.1.0" }
+cosmwasm-crypto = { path = "../crypto", package = "cosmwasm-crypto", version = "1.1.0" }
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../schema" }
 # The chrono dependency is only used in an example, which Rust compiles for us. If this causes trouble, remove it.
 chrono = { version = "0.4", default-features = false, features = [
     "alloc",
-    "std"
+    "std",
 ] }
 hex = "0.4"
 hex-literal = "0.3.1"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -57,7 +57,7 @@ hex = "0.4"
 uint = "0.9.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-cosmwasm-crypto = { path = "../crypto", package = "cosmwasm-crypto", version = "1.1.0" }
+cosmwasm-crypto = { path = "../crypto", version = "1.1.0" }
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../schema" }

--- a/packages/std/README.md
+++ b/packages/std/README.md
@@ -1,7 +1,5 @@
 # cosmwasm
 
-[![secret-cosmwasm-std on crates.io](https://img.shields.io/crates/v/secret-cosmwasm-std.svg)](https://crates.io/crates/secret-cosmwasm-std)
-
 NOTE: This is a fork of the original cosmwasm-storage repository adapted for use in [SecretNetwork](https://scrt.network)'s Secret Contracts.
 
 The standard library for building CosmWasm smart contracts. Code in this package

--- a/packages/std/examples/schema.rs
+++ b/packages/std/examples/schema.rs
@@ -2,7 +2,7 @@ use std::env::current_dir;
 use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, schema_for};
-use secret_cosmwasm_std::{BlockInfo, CosmosMsg, Empty, QueryRequest, Timestamp};
+use cosmwasm_std::{BlockInfo, CosmosMsg, Empty, QueryRequest, Timestamp};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -39,8 +39,7 @@ impl Addr {
     /// ## Examples
     ///
     /// ```
-    /// # use cosmwasm_std as coswasm_std;
-    /// # use coswasm_std::{Addr};
+    /// # use cosmwasm_std::{Addr};
     /// let address = Addr::unchecked("foobar");
     /// assert_eq!(address, "foobar");
     /// ```

--- a/packages/std/src/addresses.rs
+++ b/packages/std/src/addresses.rs
@@ -39,7 +39,7 @@ impl Addr {
     /// ## Examples
     ///
     /// ```
-    /// # use secret_cosmwasm_std as coswasm_std;
+    /// # use cosmwasm_std as coswasm_std;
     /// # use coswasm_std::{Addr};
     /// let address = Addr::unchecked("foobar");
     /// assert_eq!(address, "foobar");

--- a/packages/std/src/assertions.rs
+++ b/packages/std/src/assertions.rs
@@ -15,7 +15,7 @@
 /// #
 /// # fn body() -> Result<(), ContractError> {
 /// # let permissions = Permissions { delegate: true };
-/// use secret_cosmwasm_std::ensure;
+/// use cosmwasm_std::ensure;
 /// ensure!(permissions.delegate, ContractError::DelegatePerm {});
 ///
 /// // is the same as
@@ -39,7 +39,7 @@ macro_rules! ensure {
 /// it returns the third argument `x` wrapped in `Err(x)`.
 ///
 /// ```
-/// # use secret_cosmwasm_std::{MessageInfo, Addr};
+/// # use cosmwasm_std::{MessageInfo, Addr};
 /// #
 /// # enum ContractError {
 /// #     Unauthorized {},
@@ -51,7 +51,7 @@ macro_rules! ensure {
 /// # fn body() -> Result<(), ContractError> {
 /// # let info = MessageInfo { sender: Addr::unchecked("foo"), funds: Vec::new() };
 /// # let cfg = Config { admin: "foo".to_string() };
-/// use secret_cosmwasm_std::ensure_eq;
+/// use cosmwasm_std::ensure_eq;
 ///
 /// ensure_eq!(info.sender, cfg.admin, ContractError::Unauthorized {});
 ///
@@ -83,7 +83,7 @@ macro_rules! ensure_eq {
 /// #
 /// # fn body() -> Result<(), ContractError> {
 /// # let voting_power = 123;
-/// use secret_cosmwasm_std::ensure_ne;
+/// use cosmwasm_std::ensure_ne;
 ///
 /// ensure_ne!(voting_power, 0, ContractError::NotAVoter {});
 ///

--- a/packages/std/src/binary.rs
+++ b/packages/std/src/binary.rs
@@ -39,7 +39,7 @@ impl Binary {
     /// Copy to array of explicit length
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::Binary;
     /// let binary = Binary::from(&[0xfb, 0x1f, 0x37]);
     /// let array: [u8; 3] = binary.to_array().unwrap();
@@ -49,7 +49,7 @@ impl Binary {
     /// Copy to integer
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::Binary;
     /// let binary = Binary::from(&[0x8b, 0x67, 0x64, 0x84, 0xb5, 0xfb, 0x1f, 0x37]);
     /// let num = u64::from_be_bytes(binary.to_array().unwrap());

--- a/packages/std/src/binary.rs
+++ b/packages/std/src/binary.rs
@@ -39,7 +39,6 @@ impl Binary {
     /// Copy to array of explicit length
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::Binary;
     /// let binary = Binary::from(&[0xfb, 0x1f, 0x37]);
     /// let array: [u8; 3] = binary.to_array().unwrap();
@@ -49,7 +48,6 @@ impl Binary {
     /// Copy to integer
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::Binary;
     /// let binary = Binary::from(&[0x8b, 0x67, 0x64, 0x84, 0xb5, 0xfb, 0x1f, 0x37]);
     /// let num = u64::from_be_bytes(binary.to_array().unwrap());

--- a/packages/std/src/coin.rs
+++ b/packages/std/src/coin.rs
@@ -34,7 +34,6 @@ impl fmt::Display for Coin {
 /// # Examples
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{coins, BankMsg, CosmosMsg, Response, SubMsg};
 /// # use cosmwasm_std::testing::{mock_env, mock_info};
 /// # let env = mock_env();
@@ -56,7 +55,6 @@ pub fn coins(amount: u128, denom: impl Into<String>) -> Vec<Coin> {
 /// # Examples
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{coin, BankMsg, CosmosMsg, Response, SubMsg};
 /// # use cosmwasm_std::testing::{mock_env, mock_info};
 /// # let env = mock_env();

--- a/packages/std/src/coin.rs
+++ b/packages/std/src/coin.rs
@@ -34,7 +34,7 @@ impl fmt::Display for Coin {
 /// # Examples
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{coins, BankMsg, CosmosMsg, Response, SubMsg};
 /// # use cosmwasm_std::testing::{mock_env, mock_info};
 /// # let env = mock_env();
@@ -56,7 +56,7 @@ pub fn coins(amount: u128, denom: impl Into<String>) -> Vec<Coin> {
 /// # Examples
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{coin, BankMsg, CosmosMsg, Response, SubMsg};
 /// # use cosmwasm_std::testing::{mock_env, mock_info};
 /// # let env = mock_env();

--- a/packages/std/src/hex_binary.rs
+++ b/packages/std/src/hex_binary.rs
@@ -35,7 +35,7 @@ impl HexBinary {
     /// Copy to array of explicit length
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::HexBinary;
     /// let data = HexBinary::from(&[0xfb, 0x1f, 0x37]);
     /// let array: [u8; 3] = data.to_array().unwrap();
@@ -45,7 +45,7 @@ impl HexBinary {
     /// Copy to integer
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::HexBinary;
     /// let data = HexBinary::from(&[0x8b, 0x67, 0x64, 0x84, 0xb5, 0xfb, 0x1f, 0x37]);
     /// let num = u64::from_be_bytes(data.to_array().unwrap());

--- a/packages/std/src/hex_binary.rs
+++ b/packages/std/src/hex_binary.rs
@@ -35,7 +35,6 @@ impl HexBinary {
     /// Copy to array of explicit length
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::HexBinary;
     /// let data = HexBinary::from(&[0xfb, 0x1f, 0x37]);
     /// let array: [u8; 3] = data.to_array().unwrap();
@@ -45,7 +44,6 @@ impl HexBinary {
     /// Copy to integer
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::HexBinary;
     /// let data = HexBinary::from(&[0x8b, 0x67, 0x64, 0x84, 0xb5, 0xfb, 0x1f, 0x37]);
     /// let num = u64::from_be_bytes(data.to_array().unwrap());

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -84,7 +84,7 @@ impl Decimal {
     /// ## Examples
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Decimal, Uint128};
     /// let a = Decimal::from_atomics(Uint128::new(1234), 3).unwrap();
     /// assert_eq!(a.to_string(), "1.234");
@@ -166,7 +166,7 @@ impl Decimal {
     /// ## Examples
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Decimal, Uint128};
     /// # use std::str::FromStr;
     /// // Value with whole and fractional part

--- a/packages/std/src/math/decimal.rs
+++ b/packages/std/src/math/decimal.rs
@@ -84,7 +84,6 @@ impl Decimal {
     /// ## Examples
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Decimal, Uint128};
     /// let a = Decimal::from_atomics(Uint128::new(1234), 3).unwrap();
     /// assert_eq!(a.to_string(), "1.234");
@@ -166,7 +165,6 @@ impl Decimal {
     /// ## Examples
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Decimal, Uint128};
     /// # use std::str::FromStr;
     /// // Value with whole and fractional part

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -94,7 +94,6 @@ impl Decimal256 {
     /// ## Examples
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Decimal256, Uint256};
     /// let a = Decimal256::from_atomics(1234u64, 3).unwrap();
     /// assert_eq!(a.to_string(), "1.234");
@@ -179,7 +178,6 @@ impl Decimal256 {
     /// ## Examples
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Decimal256, Uint256};
     /// # use std::str::FromStr;
     /// // Value with whole and fractional part

--- a/packages/std/src/math/decimal256.rs
+++ b/packages/std/src/math/decimal256.rs
@@ -94,7 +94,7 @@ impl Decimal256 {
     /// ## Examples
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Decimal256, Uint256};
     /// let a = Decimal256::from_atomics(1234u64, 3).unwrap();
     /// assert_eq!(a.to_string(), "1.234");
@@ -179,7 +179,7 @@ impl Decimal256 {
     /// ## Examples
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Decimal256, Uint256};
     /// # use std::str::FromStr;
     /// // Value with whole and fractional part

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -21,7 +21,6 @@ use crate::{ConversionOverflowError, Uint256, Uint64};
 /// Use `from` to create instances of this and `u128` to get the value out:
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::Uint128;
 /// let a = Uint128::from(123u128);
 /// assert_eq!(a.u128(), 123);
@@ -125,7 +124,6 @@ impl Uint128 {
     /// # Examples
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::Uint128;
     ///
     /// let a = Uint128::MAX;

--- a/packages/std/src/math/uint128.rs
+++ b/packages/std/src/math/uint128.rs
@@ -21,7 +21,7 @@ use crate::{ConversionOverflowError, Uint256, Uint64};
 /// Use `from` to create instances of this and `u128` to get the value out:
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::Uint128;
 /// let a = Uint128::from(123u128);
 /// assert_eq!(a.u128(), 123);
@@ -125,7 +125,7 @@ impl Uint128 {
     /// # Examples
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::Uint128;
     ///
     /// let a = Uint128::MAX;

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -37,7 +37,6 @@ use uints::U256;
 /// endian bytes:
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::Uint256;
 /// let a = Uint256::from(258u128);
 /// let b = Uint256::new([
@@ -208,7 +207,6 @@ impl Uint256 {
     /// # Examples
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::Uint256;
     ///
     /// let a = Uint256::MAX;

--- a/packages/std/src/math/uint256.rs
+++ b/packages/std/src/math/uint256.rs
@@ -37,7 +37,7 @@ use uints::U256;
 /// endian bytes:
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::Uint256;
 /// let a = Uint256::from(258u128);
 /// let b = Uint256::new([
@@ -208,7 +208,7 @@ impl Uint256 {
     /// # Examples
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::Uint256;
     ///
     /// let a = Uint256::MAX;

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -35,7 +35,7 @@ use uints::U512;
 /// endian bytes:
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::Uint512;
 /// let a = Uint512::from(258u128);
 /// let b = Uint512::new([

--- a/packages/std/src/math/uint512.rs
+++ b/packages/std/src/math/uint512.rs
@@ -35,7 +35,6 @@ use uints::U512;
 /// endian bytes:
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::Uint512;
 /// let a = Uint512::from(258u128);
 /// let b = Uint512::new([

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -20,7 +20,6 @@ use crate::Uint128;
 /// Use `from` to create instances of this and `u64` to get the value out:
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::Uint64;
 /// let a = Uint64::from(42u64);
 /// assert_eq!(a.u64(), 42);
@@ -121,7 +120,6 @@ impl Uint64 {
     /// # Examples
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::Uint64;
     ///
     /// let a = Uint64::MAX;

--- a/packages/std/src/math/uint64.rs
+++ b/packages/std/src/math/uint64.rs
@@ -20,7 +20,7 @@ use crate::Uint128;
 /// Use `from` to create instances of this and `u64` to get the value out:
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::Uint64;
 /// let a = Uint64::from(42u64);
 /// assert_eq!(a.u64(), 42);
@@ -121,7 +121,7 @@ impl Uint64 {
     /// # Examples
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::Uint64;
     ///
     /// let a = Uint64::MAX;

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -55,7 +55,6 @@ pub enum QueryRequest<C> {
 /// # Examples
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::CustomQuery;
 /// # use schemars::JsonSchema;
 /// # use serde::{Deserialize, Serialize};

--- a/packages/std/src/query/mod.rs
+++ b/packages/std/src/query/mod.rs
@@ -55,7 +55,7 @@ pub enum QueryRequest<C> {
 /// # Examples
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::CustomQuery;
 /// # use schemars::JsonSchema;
 /// # use serde::{Deserialize, Serialize};

--- a/packages/std/src/results/contract_result.rs
+++ b/packages/std/src/results/contract_result.rs
@@ -15,7 +15,7 @@ use std::fmt;
 /// Success:
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{to_vec, ContractResult, Response};
 /// let response: Response = Response::default();
 /// let result: ContractResult<Response> = ContractResult::Ok(response);
@@ -25,7 +25,7 @@ use std::fmt;
 /// Failure:
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{to_vec, ContractResult, Response};
 /// let error_msg = String::from("Something went wrong");
 /// let result: ContractResult<Response> = ContractResult::Err(error_msg);

--- a/packages/std/src/results/contract_result.rs
+++ b/packages/std/src/results/contract_result.rs
@@ -15,7 +15,6 @@ use std::fmt;
 /// Success:
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{to_vec, ContractResult, Response};
 /// let response: Response = Response::default();
 /// let result: ContractResult<Response> = ContractResult::Ok(response);
@@ -25,7 +24,6 @@ use std::fmt;
 /// Failure:
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{to_vec, ContractResult, Response};
 /// let error_msg = String::from("Something went wrong");
 /// let result: ContractResult<Response> = ContractResult::Err(error_msg);

--- a/packages/std/src/results/response.rs
+++ b/packages/std/src/results/response.rs
@@ -16,7 +16,7 @@ use super::{Attribute, CosmosMsg, Empty, Event, SubMsg};
 /// Direct:
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{Binary, DepsMut, Env, MessageInfo};
 /// # type InstantiateMsg = ();
 /// #
@@ -37,7 +37,7 @@ use super::{Attribute, CosmosMsg, Empty, Event, SubMsg};
 /// Mutating:
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{coins, BankMsg, Binary, DepsMut, Env, MessageInfo, SubMsg};
 /// # type InstantiateMsg = ();
 /// # type MyError = ();
@@ -157,7 +157,7 @@ impl<T> Response<T> {
     /// Adding a list of attributes using the pair notation for key and value:
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::Response;
     ///
     /// let attrs = vec![
@@ -172,7 +172,7 @@ impl<T> Response<T> {
     /// Adding an optional value as an optional attribute by turning it into a list of 0 or 1 elements:
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::{Attribute, Response};
     ///
     /// // Some value
@@ -204,7 +204,7 @@ impl<T> Response<T> {
     /// ## Examples
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::{CosmosMsg, Response};
     ///
     /// fn make_response_with_msgs(msgs: Vec<CosmosMsg>) -> Response {
@@ -220,7 +220,7 @@ impl<T> Response<T> {
     /// ## Examples
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::{SubMsg, Response};
     ///
     /// fn make_response_with_submsgs(msgs: Vec<SubMsg>) -> Response {

--- a/packages/std/src/results/response.rs
+++ b/packages/std/src/results/response.rs
@@ -16,7 +16,6 @@ use super::{Attribute, CosmosMsg, Empty, Event, SubMsg};
 /// Direct:
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{Binary, DepsMut, Env, MessageInfo};
 /// # type InstantiateMsg = ();
 /// #
@@ -37,7 +36,6 @@ use super::{Attribute, CosmosMsg, Empty, Event, SubMsg};
 /// Mutating:
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{coins, BankMsg, Binary, DepsMut, Env, MessageInfo, SubMsg};
 /// # type InstantiateMsg = ();
 /// # type MyError = ();
@@ -157,7 +155,6 @@ impl<T> Response<T> {
     /// Adding a list of attributes using the pair notation for key and value:
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::Response;
     ///
     /// let attrs = vec![
@@ -172,7 +169,6 @@ impl<T> Response<T> {
     /// Adding an optional value as an optional attribute by turning it into a list of 0 or 1 elements:
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::{Attribute, Response};
     ///
     /// // Some value
@@ -204,7 +200,6 @@ impl<T> Response<T> {
     /// ## Examples
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::{CosmosMsg, Response};
     ///
     /// fn make_response_with_msgs(msgs: Vec<CosmosMsg>) -> Response {
@@ -220,7 +215,6 @@ impl<T> Response<T> {
     /// ## Examples
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// use cosmwasm_std::{SubMsg, Response};
     ///
     /// fn make_response_with_submsgs(msgs: Vec<SubMsg>) -> Response {

--- a/packages/std/src/results/submessages.rs
+++ b/packages/std/src/results/submessages.rs
@@ -73,7 +73,6 @@ impl<T> SubMsg<T> {
     /// ## Examples
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{coins, BankMsg, ReplyOn, SubMsg};
     /// # let msg = BankMsg::Send { to_address: String::from("you"), amount: coins(1015, "earth") };
     /// let sub_msg: SubMsg = SubMsg::reply_always(msg, 1234).with_gas_limit(60_000);
@@ -121,7 +120,6 @@ pub struct Reply {
 /// Success:
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{to_vec, Binary, Event, SubMsgResponse, SubMsgResult};
 /// let response = SubMsgResponse {
 ///     data: Some(Binary::from_base64("MTIzCg==").unwrap()),
@@ -134,7 +132,6 @@ pub struct Reply {
 /// Failure:
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{to_vec, SubMsgResult, Response};
 /// let error_msg = String::from("Something went wrong");
 /// let result = SubMsgResult::Err(error_msg);

--- a/packages/std/src/results/submessages.rs
+++ b/packages/std/src/results/submessages.rs
@@ -73,7 +73,7 @@ impl<T> SubMsg<T> {
     /// ## Examples
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{coins, BankMsg, ReplyOn, SubMsg};
     /// # let msg = BankMsg::Send { to_address: String::from("you"), amount: coins(1015, "earth") };
     /// let sub_msg: SubMsg = SubMsg::reply_always(msg, 1234).with_gas_limit(60_000);
@@ -121,7 +121,7 @@ pub struct Reply {
 /// Success:
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{to_vec, Binary, Event, SubMsgResponse, SubMsgResult};
 /// let response = SubMsgResponse {
 ///     data: Some(Binary::from_base64("MTIzCg==").unwrap()),
@@ -134,7 +134,7 @@ pub struct Reply {
 /// Failure:
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{to_vec, SubMsgResult, Response};
 /// let error_msg = String::from("Something went wrong");
 /// let result = SubMsgResult::Err(error_msg);

--- a/packages/std/src/results/system_result.rs
+++ b/packages/std/src/results/system_result.rs
@@ -15,7 +15,7 @@ use super::super::errors::SystemError;
 /// Success:
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{to_vec, Binary, ContractResult, SystemResult};
 /// let data = Binary::from(b"hello, world");
 /// let result = SystemResult::Ok(ContractResult::Ok(data));
@@ -25,7 +25,7 @@ use super::super::errors::SystemError;
 /// Failure:
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{to_vec, Binary, ContractResult, SystemResult, SystemError};
 /// let error = SystemError::Unknown {};
 /// let result: SystemResult<Binary> = SystemResult::Err(error);

--- a/packages/std/src/results/system_result.rs
+++ b/packages/std/src/results/system_result.rs
@@ -15,7 +15,6 @@ use super::super::errors::SystemError;
 /// Success:
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{to_vec, Binary, ContractResult, SystemResult};
 /// let data = Binary::from(b"hello, world");
 /// let result = SystemResult::Ok(ContractResult::Ok(data));
@@ -25,7 +24,6 @@ use super::super::errors::SystemError;
 /// Failure:
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::{to_vec, Binary, ContractResult, SystemResult, SystemError};
 /// let error = SystemError::Unknown {};
 /// let result: SystemResult<Binary> = SystemResult::Err(error);

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -1532,7 +1532,7 @@ mod tests {
         });
         match result {
             SystemResult::Ok(ContractResult::Err(err)) => {
-                assert_eq!(err, "Error parsing into type secret_cosmwasm_std::testing::mock::tests::wasm_querier_works::{{closure}}::MyMsg: Invalid type")
+                assert_eq!(err, "Error parsing into type cosmwasm_std::testing::mock::tests::wasm_querier_works::{{closure}}::MyMsg: Invalid type")
             }
             res => panic!("Unexpected result: {:?}", res),
         }

--- a/packages/std/src/timestamp.rs
+++ b/packages/std/src/timestamp.rs
@@ -11,7 +11,6 @@ use crate::math::Uint64;
 /// ## Examples
 ///
 /// ```
-/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::Timestamp;
 /// let ts = Timestamp::from_nanos(1_000_000_202);
 /// assert_eq!(ts.nanos(), 1_000_000_202);

--- a/packages/std/src/timestamp.rs
+++ b/packages/std/src/timestamp.rs
@@ -11,7 +11,7 @@ use crate::math::Uint64;
 /// ## Examples
 ///
 /// ```
-/// # use secret_cosmwasm_std as cosmwasm_std;
+/// # use cosmwasm_std as cosmwasm_std;
 /// # use cosmwasm_std::Timestamp;
 /// let ts = Timestamp::from_nanos(1_000_000_202);
 /// assert_eq!(ts.nanos(), 1_000_000_202);

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -84,7 +84,7 @@ pub trait Api {
     /// ## Examples
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Api, Addr};
     /// # use cosmwasm_std::testing::MockApi;
     /// # let api = MockApi::default();
@@ -445,5 +445,4 @@ mod tests {
         let all_balances = wrapper.query_all_balances("foo").unwrap();
         assert_eq!(all_balances, vec![coin(123, "ELF"), coin(777, "FLY")]);
     }
-
 }

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -84,7 +84,6 @@ pub trait Api {
     /// ## Examples
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Api, Addr};
     /// # use cosmwasm_std::testing::MockApi;
     /// # let api = MockApi::default();

--- a/packages/std/src/types.rs
+++ b/packages/std/src/types.rs
@@ -40,7 +40,6 @@ pub struct BlockInfo {
     /// Using chrono:
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Addr, BlockInfo, ContractInfo, Env, MessageInfo, Timestamp, TransactionInfo};
     /// # let env = Env {
     /// #     block: BlockInfo {
@@ -64,7 +63,6 @@ pub struct BlockInfo {
     /// Creating a simple millisecond-precision timestamp (as used in JavaScript):
     ///
     /// ```
-    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Addr, BlockInfo, ContractInfo, Env, MessageInfo, Timestamp, TransactionInfo};
     /// # let env = Env {
     /// #     block: BlockInfo {

--- a/packages/std/src/types.rs
+++ b/packages/std/src/types.rs
@@ -40,7 +40,7 @@ pub struct BlockInfo {
     /// Using chrono:
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Addr, BlockInfo, ContractInfo, Env, MessageInfo, Timestamp, TransactionInfo};
     /// # let env = Env {
     /// #     block: BlockInfo {
@@ -64,7 +64,7 @@ pub struct BlockInfo {
     /// Creating a simple millisecond-precision timestamp (as used in JavaScript):
     ///
     /// ```
-    /// # use secret_cosmwasm_std as cosmwasm_std;
+    /// # use cosmwasm_std as cosmwasm_std;
     /// # use cosmwasm_std::{Addr, BlockInfo, ContractInfo, Env, MessageInfo, Timestamp, TransactionInfo};
     /// # let env = Env {
     /// #     block: BlockInfo {

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
-name = "secret-cosmwasm-storage"
+name = "cosmwasm-storage"
 version = "1.1.0"
-authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>", "SCRT Labs <info@scrtlabs.com>"]
+authors = [
+    "Ethan Frey <ethanfrey@users.noreply.github.com>",
+    "SCRT Labs <info@scrtlabs.com>",
+]
 edition = "2021"
 description = "CosmWasm library with useful helpers for Storage patterns"
 repository = "https://github.com/scrtlabs/cosmwasm/tree/secret/packages/storage"
@@ -16,8 +19,8 @@ iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { version = "1.1.0", path = "../std", package = "secret-cosmwasm-std", default-features = false }
+cosmwasm-std = { version = "1.1.0", path = "../std", package = "cosmwasm-std", default-features = false }
 serde = { version = "1.0.103", default-features = false, features = [
     "derive",
-    "alloc"
+    "alloc",
 ] }

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -19,7 +19,7 @@ iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { version = "1.1.0", path = "../std", package = "cosmwasm-std", default-features = false }
+cosmwasm-std = { version = "1.1.0", path = "../std", default-features = false }
 serde = { version = "1.0.103", default-features = false, features = [
     "derive",
     "alloc",

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,7 +1,5 @@
 # cosmwasm-storage
 
-[![secret-cosmwasm-storage on crates.io](https://img.shields.io/crates/v/secret-cosmwasm-storage.svg)](https://crates.io/crates/secret-cosmwasm-storage)
-
 NOTE: This is a fork of the original cosmwasm-storage repository adapted for use in [SecretNetwork](https://scrt.network)'s Secret Contracts.
 
 CosmWasm library with useful helpers for Storage patterns. You can use `Storage`

--- a/packages/storage/src/type_helpers.rs
+++ b/packages/storage/src/type_helpers.rs
@@ -81,7 +81,7 @@ mod tests {
         let parsed = must_deserialize::<Person>(&None);
         match parsed.unwrap_err() {
             StdError::NotFound { kind, .. } => {
-                assert_eq!(kind, "secret_cosmwasm_storage::type_helpers::tests::Person")
+                assert_eq!(kind, "cosmwasm_storage::type_helpers::tests::Person")
             }
             e => panic!("Unexpected error {}", e),
         }


### PR DESCRIPTION
The chosen path is to change the names of our versions of cosmwasm std packages to `cosmwasm-*` (i.e. to be the same as vanilla).

Reasoning:

Seems like keeping the package name as `secret-cosmwasm-*` prevents us from using any libraries that are intended for the vanilla cosmwasm.

The reason is that you can't patch a crate with a differently named crate.

For example:

`cw-storage-plus` internally uses `cosmwasm-storage` as a dependency. We would want to patch that, but since our crate is called `secret-cosmwasm-storage`, the patch would not apply here.

Related source: https://github.com/rust-lang/cargo/issues/9227

On the other hand, having our packages named `cosmwasm-*` allows the above and does not prevent us from doing things like [crosschain-single-codebase-contracts](https://github.com/scrtlabs/crosschain-contract-demo/tree/old-std-name) (meaning using both vanilla and secret versions as dependencies of the same crate) - you would just need to separate them with features.

The downside is that we will not be able to publish our version to crates.io, meaning that importing this crate will look like this:

```toml
cosmwasm-std = { git = "https://github.com/scrtlabs/cosmwasm", tag = "v1.1.0" }

# Instead of:

cosmwasm-std = { package = "secret-cosmwasm-std", version = "1.1" }
```
(this is just a semantic difference - no difference in functionality)
