### PR TITLE
Bump versions to 1.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.0"
+version = "1.1.9"
 dependencies = [
  "base64",
  "criterion",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.0"
+version = "1.1.9"
 dependencies = [
  "cosmwasm-std",
  "syn",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.0"
+version = "1.1.9"
 dependencies = [
  "anyhow",
  "cosmwasm-schema-derive",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.0"
+version = "1.1.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.0"
+version = "1.1.9"
 dependencies = [
  "base64",
  "chrono",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.1.0"
+version = "1.1.9"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -1023,9 +1023,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "d56e159d99e6c2b93995d171050271edb50ecc5288fbc7cc17de8fdce4e58c14"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -98,7 +98,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.0"
+version = "1.1.9"
 dependencies = [
  "digest 0.10.6",
  "ed25519-zebra",
@@ -109,14 +109,14 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.0"
+version = "1.1.9"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.0"
+version = "1.1.9"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.0"
+version = "1.1.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.0"
+version = "1.1.9"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.1.0"
+version = "1.1.9"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -653,9 +653,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "d56e159d99e6c2b93995d171050271edb50ecc5288fbc7cc17de8fdce4e58c14"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-crypto"
-version = "1.1.0"
+version = "1.1.9"
 authors = [
     "Mauro Lacy <maurolacy@users.noreply.github.com>",
     "SCRT Labs <info@scrtlabs.com>",

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-derive"
-version = "1.1.0"
+version = "1.1.9"
 authors = ["Simon Warta <webmaster128@users.noreply.github.com>"]
 edition = "2021"
 description = "A package for auto-generated code used for CosmWasm contract development. This is shipped as part of cosmwasm-std. Do not use directly."

--- a/packages/schema-derive/Cargo.toml
+++ b/packages/schema-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-schema-derive"
-version = "1.1.0"
+version = "1.1.9"
 authors = ["Tomasz Kurcz <tom@confio.gmbh>"]
 edition = "2021"
 description = "Derive macros for cosmwasm-schema"

--- a/packages/schema/Cargo.toml
+++ b/packages/schema/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
 name = "cosmwasm-schema"
-version = "1.1.0"
-authors = ["Simon Warta <webmaster128@users.noreply.github.com>", "Ethan Frey <ethanfrey@users.noreply.github.com>"]
+version = "1.1.9"
+authors = [
+    "Simon Warta <webmaster128@users.noreply.github.com>",
+    "Ethan Frey <ethanfrey@users.noreply.github.com>",
+]
 edition = "2021"
 description = "A dev-dependency for CosmWasm contracts to generate JSON Schema files."
 repository = "https://github.com/CosmWasm/cosmwasm/tree/main/packages/schema"
 license = "Apache-2.0"
 
 [dependencies]
-cosmwasm-schema-derive = { version = "=1.1.0", path = "../schema-derive" }
+cosmwasm-schema-derive = { version = "=1.1.9", path = "../schema-derive" }
 schemars = "0.8.3"
 serde = "1.0"
 serde_json = "1.0.40"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-std"
-version = "1.1.0"
+version = "1.1.9"
 authors = [
     "Ethan Frey <ethanfrey@users.noreply.github.com>",
     "SCRT Labs <info@scrtlabs.com>",
@@ -42,7 +42,7 @@ cosmwasm_1_1 = []
 
 [dependencies]
 base64 = "0.13.0"
-cosmwasm-derive = { path = "../derive", version = "1.1.0" }
+cosmwasm-derive = { path = "../derive", version = "1.1.9" }
 
 serde-json-wasm = { version = "0.4.1" }
 schemars = "0.8.3"
@@ -57,7 +57,7 @@ hex = "0.4"
 uint = "0.9.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-cosmwasm-crypto = { path = "../crypto", version = "1.1.0" }
+cosmwasm-crypto = { path = "../crypto", version = "1.1.9" }
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../schema" }

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-storage"
-version = "1.1.0"
+version = "1.1.9"
 authors = [
     "Ethan Frey <ethanfrey@users.noreply.github.com>",
     "SCRT Labs <info@scrtlabs.com>",
@@ -19,7 +19,7 @@ iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { version = "1.1.0", path = "../std", default-features = false }
+cosmwasm-std = { version = "1.1.9", path = "../std", default-features = false }
 serde = { version = "1.0.103", default-features = false, features = [
     "derive",
     "alloc",


### PR DESCRIPTION
Since we've caught up to CosmWasm v1.1.9, this is to support libraries that specify `cosmwasm-*` libraries to a path level (`1.1.x`).