### PR TITLE
Convert hash to String from &str in mock.rs

### DIFF
--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -253,7 +253,7 @@ pub fn mock_env() -> Env {
                 Binary::from_base64("wLsKdf/sYqvSMI0G0aWRjob25mrIB0VQVjTjDXnDafk=").unwrap(),
             ),
         },
-        transaction: Some(TransactionInfo { index: 3, hash: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" }),
+        transaction: Some(TransactionInfo { index: 3, hash: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_string() }),
         contract: ContractInfo {
             address: Addr::unchecked(MOCK_CONTRACT_ADDR),
             code_hash: "".to_string(),


### PR DESCRIPTION
Cargo fails to do compilation due to this bug when referencing to this branch
It is referenced in [ibc-hooks-contract](https://github.com/scrtlabs/secret.js/tree/master/test/ibc-hooks-contract) for example
